### PR TITLE
Service tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Utilities for managing Phabricator install
 If you have questions use [Issues](https://github.com/neandrake/phab-utils/issues), if you would like to contribute use [Pull Requests](https://github.com/neandrake/phab-utils/pulls).
 
 #### TODO
-- [ ] Create `systemd` service files for aplict and phd. Currently these do not startup when the system reboots.
 - [ ] Consider creating a single `systemd` service file to manage all services using something similar to `service` script.
 
 ### Environment
@@ -44,8 +43,15 @@ If you use this script there are some variables at the top of the file which you
   - `REVLOG` - Path to file for storing the upgrade log. During each upgrade the database dump is logged along with each of the git repository `HEAD` revision prior to the upgrade. This is useful in the event of needing to restore to a previous working version.
   - `PHAB_USER` - Several actions are performed under this account, detailed above. The `ROOT` directory is set to be owned by this account.
   - `PHAB_GROUP` - The group account which the `ROOT` directory is set to be owned by, detailed above.
-  - `PHAB_PHD_USER` - The user account which the phd daemons runs as, detailed above.
-  - `WEB_USER` - THe user account which the http/nginx service runs as, detailed above.
+
+#### Configure the systemd scripts
+The service script relies on systemd scripts to manage Aphlict and the Phabricator PHD daemons.
+To use the included systemd scripts, move them to /etc/systemd/system and then run `systemctl daemon-reload`.
+
+These systemd scripts may be configured as follows:
+- `User=` - The user that this systemd script runs as.
+- `ExecStart=` - The command that runs when `systemctl start XXX.service` is run. The default values reflect the path structure specified in the "Environment" section.
+- `ExecStart=` - The command that runs when `systemctl stop XXX.service` is run, detailed above.
 
 #### Commands:
 ##### Stop/Start

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ If you use this script there are some variables at the top of the file which you
   - `REVLOG` - Path to file for storing the upgrade log. During each upgrade the database dump is logged along with each of the git repository `HEAD` revision prior to the upgrade. This is useful in the event of needing to restore to a previous working version.
   - `PHAB_USER` - Several actions are performed under this account, detailed above. The `ROOT` directory is set to be owned by this account.
   - `PHAB_GROUP` - The group account which the `ROOT` directory is set to be owned by, detailed above.
+  - `MAX_BACKUPS` - Only keep this many system backups in $BAKPATH. Defaults to 3.
 
 #### Configure the systemd scripts
 The service script relies on systemd scripts to manage Aphlict and the Phabricator PHD daemons.
@@ -78,7 +79,8 @@ Upgrades the phabricator install to the latest version, creating a backup of the
 5. Updates each of the repositories, `libphutil`, `arcanist`, and `phabricator`, for each one updating the log to indicate which commit each one was previously at and upgraded to.
 6. Updates the ownership of the phabricator install files/folders.
 7. Runs database migration using `./bin/storage upgrade`.
-8. Starts all services
+8. Cleans out old Phabricator backups.
+9. Starts all services
 
 The upgrade process is useful for creating backup of content prior to upgrade along with tracking which revision of install is used.
 

--- a/service/aphlict.service
+++ b/service/aphlict.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Aphlict Phabricator Notification Server
+After=nginx.service
+
+[Service]
+Type=forking
+User=nginx
+ExecStart=/usr/local/phacility/phabricator/bin/aphlict start
+ExecStop=/usr/local/phacility/phabricator/bin/aphlict stop
+PIDFile=/var/tmp/aphlict/pid/aphlict.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/service/phab-phd.service
+++ b/service/phab-phd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Phabricator Background Daemons
+
+[Service]
+Type=forking
+User=phab-phd
+ExecStart=/usr/local/phacility/phabricator/bin/phd start
+ExecStop=/usr/local/phacility/phabricator/bin/phd stop
+
+[Install]
+WantedBy=multi-user.target

--- a/service/service
+++ b/service/service
@@ -58,11 +58,6 @@ init () {
 	# the group which owns the phabricator install
 	PHAB_GROUP=phacility
 
-	# the user which the daemons run as
-	PHAB_PHD_USER=phab-phd
-
-	# the user which the web service and fast-cgi server run as
-	WEB_USER=nginx
 }
 
 # stops the services related to phabricator

--- a/service/service
+++ b/service/service
@@ -58,6 +58,8 @@ init () {
 	# the group which owns the phabricator install
 	PHAB_GROUP=phacility
 
+    # the maximum number of system backups to keep
+    MAX_BACKUPS=3
 }
 
 # stops the services related to phabricator
@@ -142,6 +144,10 @@ _d_upgrade () {
 
 	# run any database migrations/updates needed
 	sudo -u $PHAB_USER $ROOT/phabricator/bin/storage upgrade --force
+
+    # clear out old backups
+    cd $BAKPATH
+    ls -tp | grep -v revlog | tail -n +$(( $MAX_BACKUPS + 1)) | xargs -d '\n' rm -rf --
 }
 
 # stops services, runs upgrade, starts services

--- a/service/service
+++ b/service/service
@@ -71,10 +71,10 @@ d_stop () {
 	systemctl stop sshd-phab.service
 
 	# the daemons used by phabricator - these are what work with the repos
-	sudo -u $PHAB_PHD_USER $ROOT/phabricator/bin/phd stop
+    systemctl stop phab-phd.service
 
 	# the notification server - i'm not positive which user this should be run as, perhaps the web-server user instead?
-	sudo -u $WEB_USER $ROOT/phabricator/bin/aphlict stop
+    systemctl stop aphlict.service
 
 	# the web server
 	systemctl stop nginx.service
@@ -93,10 +93,10 @@ d_start () {
 	systemctl start nginx.service
 
 	# the daemons used by phabricator - these are what work with the repos
-	sudo -u $PHAB_PHD_USER $ROOT/phabricator/bin/phd start
+    systemctl start phab-phd.service
 
 	# the notification server - i'm not positive which user this should be run as, perhaps the web-server user instead?
-	sudo -u $WEB_USER $ROOT/phabricator/bin/aphlict start
+    systemctl start aphlict.service
 
 	# the sshd service that is specific to VCS access managed by phabricator
 	systemctl start sshd-phab.service


### PR DESCRIPTION
This adds functionality to the service script so that only $MAX_BACKUP number of system backups are kept. Defaults to 3.
